### PR TITLE
fix: Correct mis-spelled output `volumes` on Ontap sub-module

### DIFF
--- a/examples/ontap/README.md
+++ b/examples/ontap/README.md
@@ -61,7 +61,7 @@ No inputs.
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the security group |
 | <a name="output_storage_virtual_machines"></a> [storage\_virtual\_machines](#output\_storage\_virtual\_machines) | A map of ONTAP storage virtual machines created and their attributes |
-| <a name="output_volues"></a> [volues](#output\_volues) | A map of ONTAP volumes created and their attributes |
+| <a name="output_volumes"></a> [volumes](#output\_volumes) | A map of ONTAP volumes created and their attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-fsx/blob/master/LICENSE).

--- a/examples/ontap/outputs.tf
+++ b/examples/ontap/outputs.tf
@@ -41,9 +41,9 @@ output "storage_virtual_machines" {
 # ONTAP Volume(s)
 ################################################################################
 
-output "volues" {
+output "volumes" {
   description = "A map of ONTAP volumes created and their attributes"
-  value       = module.fsx_ontap.volues
+  value       = module.fsx_ontap.volumes
 }
 
 ################################################################################

--- a/modules/ontap/README.md
+++ b/modules/ontap/README.md
@@ -238,7 +238,7 @@ No modules.
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the security group |
 | <a name="output_storage_virtual_machines"></a> [storage\_virtual\_machines](#output\_storage\_virtual\_machines) | A map of ONTAP storage virtual machines created and their attributes |
-| <a name="output_volues"></a> [volues](#output\_volues) | A map of ONTAP volumes created and their attributes |
+| <a name="output_volumes"></a> [volumes](#output\_volumes) | A map of ONTAP volumes created and their attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/modules/ontap/outputs.tf
+++ b/modules/ontap/outputs.tf
@@ -40,7 +40,7 @@ output "storage_virtual_machines" {
 # ONTAP Volume(s)
 ################################################################################
 
-output "volues" {
+output "volumes" {
   description = "A map of ONTAP volumes created and their attributes"
   value       = aws_fsx_ontap_volume.this
 }


### PR DESCRIPTION
## Description
There's a typo in the output variable **volume** of this module. It's named **volues**.

## Motivation and Context
One wouldn't expect to be a typo there. My VS Code code completion plugin even proposed volumes written the right way. It's a trap for people who start using the module who're required to access the volumes attribute.

## Breaking Changes
There might be braking changes for people who:
- use the module but haven't pinned down the version and use the volues output variable

## How Has This Been Tested?
Since it's only the name of an output, I tested it locally and the change worked fine for me