### PR TITLE
feat: Add `metadata_configuration` to FSx Lustre, `aggregate_configuration` to FSx Ontap, and `file_system_endpoint_ip_address` attribute to Openzfs

### DIFF
--- a/examples/lustre/README.md
+++ b/examples/lustre/README.md
@@ -23,13 +23,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 
 ## Modules
 

--- a/examples/lustre/main.tf
+++ b/examples/lustre/main.tf
@@ -98,7 +98,7 @@ module "fsx_lustre_persistent_2" {
   automatic_backup_retention_days = 0
   data_compression_type           = "LZ4"
   deployment_type                 = "PERSISTENT_2"
-  file_system_type_version        = "2.12"
+  file_system_type_version        = "2.15"
 
   log_configuration = {
     level = "ERROR_ONLY"
@@ -108,6 +108,11 @@ module "fsx_lustre_persistent_2" {
 
   root_squash_configuration = {
     root_squash = "365534:65534"
+  }
+
+  metadata_configuration = {
+    mode = "USER_PROVISIONED"
+    iops = 1500
   }
 
   storage_capacity              = 1200

--- a/examples/lustre/versions.tf
+++ b/examples/lustre/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.53"
     }
   }
 }

--- a/examples/ontap/README.md
+++ b/examples/ontap/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 
 ## Modules
 

--- a/examples/ontap/main.tf
+++ b/examples/ontap/main.tf
@@ -58,6 +58,22 @@ module "fsx_ontap" {
         }
       }
     }
+    ex-flexgroup = {
+      name = "flexgroup"
+
+      volumes = {
+        ex-flexgroup = {
+          name                       = "flexgroup"
+          junction_path              = "/test"
+          size_in_bytes              = 1024000000000
+          storage_efficiency_enabled = true
+          volume_style               = "FLEXGROUP"
+          aggregate_configuration = {
+            constituents_per_aggregate = 9
+          }
+        }
+      }
+    }
     ex-other = {
       name                       = "one"
       root_volume_security_style = "NTFS"

--- a/examples/ontap/versions.tf
+++ b/examples/ontap/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.53"
     }
   }
 }

--- a/examples/openzfs/README.md
+++ b/examples/openzfs/README.md
@@ -55,6 +55,7 @@ No inputs.
 | <a name="output_child_volumes_snapshots"></a> [child\_volumes\_snapshots](#output\_child\_volumes\_snapshots) | A map of OpenZFS child volumes and their snapshots |
 | <a name="output_file_system_arn"></a> [file\_system\_arn](#output\_file\_system\_arn) | Amazon Resource Name of the file system |
 | <a name="output_file_system_dns_name"></a> [file\_system\_dns\_name](#output\_file\_system\_dns\_name) | DNS name for the file system, e.g., `fs-12345678.fsx.us-west-2.amazonaws.com` |
+| <a name="output_file_system_endpoint_ip_address"></a> [file\_system\_endpoint\_ip\_address](#output\_file\_system\_endpoint\_ip\_address) | IP address of the endpoint that is used to access data or to manage the file system |
 | <a name="output_file_system_id"></a> [file\_system\_id](#output\_file\_system\_id) | Identifier of the file system, e.g., `fs-12345678` |
 | <a name="output_file_system_network_interface_ids"></a> [file\_system\_network\_interface\_ids](#output\_file\_system\_network\_interface\_ids) | Set of Elastic Network Interface identifiers from which the file system is accessible. As explained in the [documentation](https://docs.aws.amazon.com/fsx/latest/LustreGuide/mounting-on-premises.html), the first network interface returned is the primary network interface |
 | <a name="output_file_system_root_volume_id"></a> [file\_system\_root\_volume\_id](#output\_file\_system\_root\_volume\_id) | Identifier of the root volume, e.g., `fsvol-12345678` |

--- a/examples/openzfs/README.md
+++ b/examples/openzfs/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 
 ## Modules
 

--- a/examples/openzfs/outputs.tf
+++ b/examples/openzfs/outputs.tf
@@ -27,6 +27,11 @@ output "file_system_network_interface_ids" {
   value       = module.fsx_openzfs.file_system_network_interface_ids
 }
 
+output "file_system_endpoint_ip_address" {
+  description = "IP address of the endpoint that is used to access data or to manage the file system"
+  value       = module.fsx_openzfs.file_system_endpoint_ip_address
+}
+
 ################################################################################
 # OpenZFS Volume(s)
 ################################################################################

--- a/examples/openzfs/versions.tf
+++ b/examples/openzfs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.53"
     }
   }
 }

--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 
 ## Modules
 

--- a/examples/windows/versions.tf
+++ b/examples/windows/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.53"
     }
   }
 }

--- a/modules/lustre/README.md
+++ b/modules/lustre/README.md
@@ -171,13 +171,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 
 ## Modules
 
@@ -231,6 +231,7 @@ No modules.
 | <a name="input_file_system_type_version"></a> [file\_system\_type\_version](#input\_file\_system\_type\_version) | Sets the Lustre version for the file system that you're creating | `string` | `null` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | ARN for the KMS Key to encrypt the file system at rest. Defaults to an AWS managed KMS Key | `string` | `null` | no |
 | <a name="input_log_configuration"></a> [log\_configuration](#input\_log\_configuration) | The configuration object for Amazon FSx for Lustre file systems used in the CreateFileSystem and CreateFileSystemFromBackup operations. | `map(string)` | <pre>{<br>  "level": "WARN_ERROR"<br>}</pre> | no |
+| <a name="input_metadata_configuration"></a> [metadata\_configuration](#input\_metadata\_configuration) | The Lustre metadata configuration used when creating an Amazon FSx for Lustre file system. This can be used to specify a user provisioned metadata scale. This is only supported when deployment\_type is set to PERSISTENT\_2 | `any` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the file system | `string` | `""` | no |
 | <a name="input_per_unit_storage_throughput"></a> [per\_unit\_storage\_throughput](#input\_per\_unit\_storage\_throughput) | Describes the amount of read and write throughput for each 1 tebibyte of storage, in MB/s/TiB, required for the `PERSISTENT_1` and `PERSISTENT_2` deployment\_type | `number` | `null` | no |
 | <a name="input_root_squash_configuration"></a> [root\_squash\_configuration](#input\_root\_squash\_configuration) | The Lustre root squash configuration used when creating an Amazon FSx for Lustre file system. When enabled, root squash restricts root-level access from clients that try to access your file system as a root user | `any` | `{}` | no |

--- a/modules/lustre/main.tf
+++ b/modules/lustre/main.tf
@@ -35,6 +35,14 @@ resource "aws_fsx_lustre_file_system" "this" {
 
   per_unit_storage_throughput = var.per_unit_storage_throughput
 
+  dynamic "metadata_configuration" {
+    for_each = length(var.metadata_configuration) > 0 ? [var.metadata_configuration] : []
+    content {
+      mode = try(metadata_configuration.value.mode, null)
+      iops = try(metadata_configuration.value.iops, null)
+    }
+  }
+
   dynamic "root_squash_configuration" {
     for_each = length(var.root_squash_configuration) > 0 ? [var.root_squash_configuration] : []
 

--- a/modules/lustre/variables.tf
+++ b/modules/lustre/variables.tf
@@ -88,6 +88,11 @@ variable "per_unit_storage_throughput" {
   default     = null
 }
 
+variable "metadata_configuration" {
+  description = "The Lustre metadata configuration used when creating an Amazon FSx for Lustre file system. This can be used to specify a user provisioned metadata scale. This is only supported when deployment_type is set to PERSISTENT_2"
+  type        = any
+  default     = {}
+}
 variable "root_squash_configuration" {
   description = "The Lustre root squash configuration used when creating an Amazon FSx for Lustre file system. When enabled, root squash restricts root-level access from clients that try to access your file system as a root user"
   type        = any

--- a/modules/lustre/versions.tf
+++ b/modules/lustre/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.53"
     }
   }
 }

--- a/modules/ontap/README.md
+++ b/modules/ontap/README.md
@@ -166,13 +166,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 
 ## Modules
 

--- a/modules/ontap/main.tf
+++ b/modules/ontap/main.tf
@@ -117,7 +117,7 @@ resource "aws_fsx_ontap_volume" "this" {
   ontap_volume_type                    = try(each.value.ontap_volume_type, null)
   security_style                       = try(each.value.security_style, null)
   size_in_bytes                        = try(each.value.size_in_bytes, null)
-  size_in_megabytes                    = each.value.size_in_megabytes
+  size_in_megabytes                    = try(each.value.size_in_megabytes, null)
   skip_final_backup                    = try(each.value.skip_final_backup, null)
 
   dynamic "aggregate_configuration" {

--- a/modules/ontap/main.tf
+++ b/modules/ontap/main.tf
@@ -116,8 +116,17 @@ resource "aws_fsx_ontap_volume" "this" {
   name                                 = try(each.value.name, each.key)
   ontap_volume_type                    = try(each.value.ontap_volume_type, null)
   security_style                       = try(each.value.security_style, null)
+  size_in_bytes                        = try(each.value.size_in_bytes, null)
   size_in_megabytes                    = each.value.size_in_megabytes
   skip_final_backup                    = try(each.value.skip_final_backup, null)
+
+  dynamic "aggregate_configuration" {
+    for_each = try([each.value.aggregate_configuration], [])
+    content {
+      aggregates                 = try(aggregate_configuration.value.aggregates, null)
+      constituents_per_aggregate = try(aggregate_configuration.value.constituents_per_aggregate, null)
+    }
+  }
 
   dynamic "snaplock_configuration" {
     for_each = try([each.value.snaplock_configuration], [])
@@ -188,7 +197,8 @@ resource "aws_fsx_ontap_volume" "this" {
     }
   }
 
-  volume_type = "ONTAP"
+  volume_style = try(each.value.volume_style, null)
+  volume_type  = "ONTAP"
 
   tags = merge(
     var.tags,

--- a/modules/ontap/versions.tf
+++ b/modules/ontap/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.53"
     }
   }
 }

--- a/modules/openzfs/README.md
+++ b/modules/openzfs/README.md
@@ -146,13 +146,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 
 ## Modules
 
@@ -218,6 +218,7 @@ No modules.
 | <a name="output_child_volumes_snapshots"></a> [child\_volumes\_snapshots](#output\_child\_volumes\_snapshots) | A map of OpenZFS child volumes and their snapshots |
 | <a name="output_file_system_arn"></a> [file\_system\_arn](#output\_file\_system\_arn) | Amazon Resource Name of the file system |
 | <a name="output_file_system_dns_name"></a> [file\_system\_dns\_name](#output\_file\_system\_dns\_name) | DNS name for the file system, e.g., `fs-12345678.fsx.us-west-2.amazonaws.com` |
+| <a name="output_file_system_endpoint_ip_address"></a> [file\_system\_endpoint\_ip\_address](#output\_file\_system\_endpoint\_ip\_address) | IP address of the endpoint that is used to access data or to manage the file system |
 | <a name="output_file_system_id"></a> [file\_system\_id](#output\_file\_system\_id) | Identifier of the file system, e.g., `fs-12345678` |
 | <a name="output_file_system_network_interface_ids"></a> [file\_system\_network\_interface\_ids](#output\_file\_system\_network\_interface\_ids) | Set of Elastic Network Interface identifiers from which the file system is accessible. As explained in the [documentation](https://docs.aws.amazon.com/fsx/latest/LustreGuide/mounting-on-premises.html), the first network interface returned is the primary network interface |
 | <a name="output_file_system_root_volume_id"></a> [file\_system\_root\_volume\_id](#output\_file\_system\_root\_volume\_id) | Identifier of the root volume, e.g., `fsvol-12345678` |

--- a/modules/openzfs/outputs.tf
+++ b/modules/openzfs/outputs.tf
@@ -27,6 +27,11 @@ output "file_system_network_interface_ids" {
   value       = try(aws_fsx_openzfs_file_system.this[0].network_interface_ids, [])
 }
 
+output "file_system_endpoint_ip_address" {
+  description = "IP address of the endpoint that is used to access data or to manage the file system"
+  value       = try(aws_fsx_openzfs_file_system.this[0].endpoint_ip_address, null)
+}
+
 ################################################################################
 # OpenZFS Volume(s)
 ################################################################################

--- a/modules/openzfs/versions.tf
+++ b/modules/openzfs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.53"
     }
   }
 }

--- a/modules/windows/README.md
+++ b/modules/windows/README.md
@@ -73,13 +73,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 
 ## Modules
 

--- a/modules/windows/versions.tf
+++ b/modules/windows/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.53"
     }
   }
 }

--- a/wrappers/lustre/main.tf
+++ b/wrappers/lustre/main.tf
@@ -35,6 +35,7 @@ module "wrapper" {
   log_configuration = try(each.value.log_configuration, var.defaults.log_configuration, {
     level = "WARN_ERROR"
   })
+  metadata_configuration         = try(each.value.metadata_configuration, var.defaults.metadata_configuration, {})
   name                           = try(each.value.name, var.defaults.name, "")
   per_unit_storage_throughput    = try(each.value.per_unit_storage_throughput, var.defaults.per_unit_storage_throughput, null)
   root_squash_configuration      = try(each.value.root_squash_configuration, var.defaults.root_squash_configuration, {})


### PR DESCRIPTION
## Description
- add `metadata_configuration` to `aws_fsx_lustre_file_system` 
- add `aggregate_configuration` to `aws_fsx_ontap_volume` 
- add `size_in_bytes` to `aws_fsx_ontap_volume`
- add `volume_style` to `aws_fsx_ontap_volume`
- add `file_system_endpoint_ip_address` attribute to openzfs module 

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/36511
https://github.com/hashicorp/terraform-provider-aws/pull/37868

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
